### PR TITLE
праверыць пунктуацыю ў апрацаваных дыялогах

### DIFF
--- a/text/dialogues/1.json
+++ b/text/dialogues/1.json
@@ -70,7 +70,7 @@
                   "articyId": "0x0100000400000063",
                   "english": "(Simply keep on non-existing.)",
                   "polish": "(Po prostu nie istniej dalej).",
-                  "belarusian": "(Проста не існаваць далей).",
+                  "belarusian": "(Проста не існаваць далей.)",
                   "links": [
                     {
                       "id": 3,
@@ -422,7 +422,7 @@
                                                                                   "articyId": "0x0100000400000EAD",
                                                                                   "english": "Somehow you know what it is -- a Coupris Kineema motor carriage.",
                                                                                   "polish": "Z jakiegoś powodu wiesz, co go wydaje – powóz motorowy marki Coupris Kineema.",
-                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае – маторная карэта маркі Coupris Kineema.",
+                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае — маторная карэта маркі Coupris Kineema.",
                                                                                   "links": [
                                                                                     {
                                                                                       "id": 74,
@@ -433,7 +433,7 @@
                                                                                       "articyId": "0x01000027000006FD",
                                                                                       "english": "[Open your eyes.]",
                                                                                       "polish": "[Otwórz oczy].",
-                                                                                      "belarusian": "[Расплюшчыць вочы].",
+                                                                                      "belarusian": "[Расплюшчыць вочы.]",
                                                                                       "links": []
                                                                                     }
                                                                                   ]
@@ -819,7 +819,7 @@
                                   "articyId": "0x0100000400005797",
                                   "english": "(Plunge back into the fathomless deep.)",
                                   "polish": "(Rzuć się ponownie w niezmierzoną głębię).",
-                                  "belarusian": "(Нырнуць назад у неспасціжную глыбіню).",
+                                  "belarusian": "(Нырнуць назад у неспасціжную глыбіню.)",
                                   "links": [
                                     {
                                       "id": 56,

--- a/text/dialogues/1.json
+++ b/text/dialogues/1.json
@@ -422,7 +422,7 @@
                                                                                   "articyId": "0x0100000400000EAD",
                                                                                   "english": "Somehow you know what it is -- a Coupris Kineema motor carriage.",
                                                                                   "polish": "Z jakiegoś powodu wiesz, co go wydaje – powóz motorowy marki Coupris Kineema.",
-                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае — маторная карэта маркі Coupris Kineema.",
+                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае, — маторная карэта маркі Coupris Kineema.",
                                                                                   "links": [
                                                                                     {
                                                                                       "id": 74,

--- a/text/dialogues/1.json
+++ b/text/dialogues/1.json
@@ -422,7 +422,7 @@
                                                                                   "articyId": "0x0100000400000EAD",
                                                                                   "english": "Somehow you know what it is -- a Coupris Kineema motor carriage.",
                                                                                   "polish": "Z jakiegoś powodu wiesz, co go wydaje – powóz motorowy marki Coupris Kineema.",
-                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае, — маторная карэта маркі Coupris Kineema.",
+                                                                                  "belarusian": "Ты аднекуль ведаеш, што яго выдае — маторная карэта маркі Coupris Kineema.",
                                                                                   "links": [
                                                                                     {
                                                                                       "id": 74,

--- a/text/dialogues/2.json
+++ b/text/dialogues/2.json
@@ -635,7 +635,7 @@
               "articyId": "0x01000004000002C0",
               "english": "A terrible mistake! Turn the lights off IMMEDIATELY! You can practically feel the photons burning a hole in your brain.",
               "polish": "Straszny błąd! NATYCHMIAST wyłącz to światło! Czujesz, jakby fotony praktycznie wypalały ci dziurę w mózgu.",
-              "belarusian": "Жудасная памылка! НЕАДКЛАДНА выключы гэта святло! Ты адчуваеш, што фатоны літаральна прапальваюць дзірку ў тваім мазгу.",
+              "belarusian": "Жудасная памылка! НЕАДКЛАДНА выключы гэта святло! Ты адчуваеш, што фатоны літаральна прапальваюць дзірку ў тваіх мазгах.",
               "links": [
                 {
                   "id": 83,
@@ -725,7 +725,7 @@
           "articyId": "0x0100000400005758",
           "english": "[Leave.]",
           "polish": "[Odejdź].",
-          "belarusian": "[Адыйсці].",
+          "belarusian": "[Адыйсці.]",
           "links": []
         }
       ]

--- a/text/dialogues/2.json
+++ b/text/dialogues/2.json
@@ -635,7 +635,7 @@
               "articyId": "0x01000004000002C0",
               "english": "A terrible mistake! Turn the lights off IMMEDIATELY! You can practically feel the photons burning a hole in your brain.",
               "polish": "Straszny błąd! NATYCHMIAST wyłącz to światło! Czujesz, jakby fotony praktycznie wypalały ci dziurę w mózgu.",
-              "belarusian": "Жудасная памылка! НЕАДКЛАДНА выключы гэта святло! Ты адчуваеш, што фатоны літаральна прапальваюць дзірку ў тваіх мазгах.",
+              "belarusian": "Жудасная памылка! НЕАДКЛАДНА выключы гэта святло! Ты адчуваеш, як фатоны літаральна прапальваюць дзірку ў тваіх мазгах.",
               "links": [
                 {
                   "id": 83,

--- a/text/dialogues/2.json
+++ b/text/dialogues/2.json
@@ -725,7 +725,7 @@
           "articyId": "0x0100000400005758",
           "english": "[Leave.]",
           "polish": "[Odejdź].",
-          "belarusian": "[Адыйсці.]",
+          "belarusian": "[Адысці.]",
           "links": []
         }
       ]

--- a/text/dialogues/23.json
+++ b/text/dialogues/23.json
@@ -110,7 +110,7 @@
                               "articyId": "0x010000040000C4B1",
                               "english": "More likely a projectile than a held object. There are no fragments on the floor from pulling a tool back in after impact.",
                               "polish": "Raczej pocisk niż trzymany w ręce przedmiot – brak na podłodze odłamków, które by na nią spadły po cofnięciu narzędzia.",
-                              "belarusian": "Больш верагодна, што прадмет кідалі, чым білі ім з замахам, — на падлозе няма аскепкаў ад таго, што прадмет вярнуўся ў пакой пасля удару.",
+                              "belarusian": "Больш верагодна, што прадмет кідалі, чым білі ім з замахам, — на падлозе няма аскепкаў ад таго, што прадмет вярнуўся ў пакой пасля ўдару.",
                               "links": [
                                 {
                                   "id": 58,

--- a/text/dialogues/3.json
+++ b/text/dialogues/3.json
@@ -621,7 +621,7 @@
                                                                                                                   "articyId": "0x0100005100009343",
                                                                                                                   "english": "You used to believe you came from a large family with many half-brothers and sisters, but where are they now? However you shout, they can't hear you...",
                                                                                                                   "polish": "Kiedyś wierzyłeś, że pochodzisz z dużej rodziny z wieloma przyrodnimi braćmi i siostrami, ale gdzie są teraz? Jak byś nie krzyczał, nie słyszą cię...",
-                                                                                                                  "belarusian": "Калісьці ты верыў, што паходзіш з вялікай сям'і са мноствам зводных братоў і сясцёр, але дзе яны цяпер? Як бы ты ні крычаў, яны цябе не чуюць...",
+                                                                                                                  "belarusian": "Калісьці ты верыў, што паходзіш з вялікай сям'і са мноствам крэўных братоў і сясцёр, але дзе яны цяпер? Як бы ты ні крычаў, яны цябе не чуюць...",
                                                                                                                   "links": []
                                                                                                                 },
                                                                                                                 {
@@ -633,7 +633,7 @@
                                                                                                                   "articyId": "0x01000051000092E4",
                                                                                                                   "english": "In a mould-covered bathroom inside a trashed hostel near the edge of Martinaise, a middle-aged man grips the sides of a cold sink in white-knuckled fury...",
                                                                                                                   "polish": "W zapleśniałej łazience zniszczonego hostelu na skraju Martinaise mężczyzna w średnim wieku w ataku furii zaciska dłonie na umywalce tak mocno, aż bieleją mu knykcie...",
-                                                                                                                  "belarusian": "У зацвілай ваннай разбуранага нумара гатэля на ўскрайку Марцінэза мужчына сярэдняга веку ў прыступе лютасці сціскае рукамі халодныя бакі ракавіны так моцна, што ў яго бялеюць костачкі пальцаў...",
+                                                                                                                  "belarusian": "У зацвілай ваннай разбуранага нумара хостэла на ўскрайку Марцінэза мужчына сярэдняга веку ў прыступе лютасці сціскае рукамі халодныя бакі ракавіны так моцна, што ў яго бялеюць костачкі пальцаў...",
                                                                                                                   "links": [
                                                                                                                     {
                                                                                                                       "id": 470,
@@ -1287,7 +1287,7 @@
                                               "articyId": "0x0100005300001C25",
                                               "english": "Now, every night, while you masturbate in the ruins of your not-so-great-anymore hall, they're getting pleasured by foreign men with superior testosterone levels and *far* more advanced sexual practices than your feeble grunt-and-thrust.",
                                               "polish": "I teraz każdej nocy, której ty masturbujesz się w ruinach swego dawnego wielkiego domostwa, one doznają zaspokojenia przez obcokrajowców o wysokim poziomie testosteronu, znających techniki seksualne o *wiele* bardziej zaawansowane od twoich żałosnych stęków i ruchów frykcyjnych.",
-                                              "belarusian": "Цяпер кожную ноч, пакуль ты мастурбуеш на руінах свайго ўжо-не-такога-велічнага палаца, іх задавальняюць замежнікі з высокім узроўнем тэстастэрону, абазнаныя ў сэксуальных тэхніках *значна* больш, чым ты са сваімі вартымі жалю стогнамі і фрыкцыямі.",
+                                              "belarusian": "Цяпер кожную ноч, пакуль ты мастурбуеш на руінах свайго ўжо-не-такога-велічнага палаца, іх задавальняюць замежнікі з высокім узроўнем тэстастэрону, абазнаныя ў сексуальных тэхніках *значна* больш, чым ты са сваімі вартымі жалю стогнамі і фрыкцыямі.",
                                               "links": [
                                                 {
                                                   "id": 90,
@@ -1599,7 +1599,7 @@
                                               "articyId": "0x01000004000059D9",
                                               "english": "Sometimes you like to add finger pistols to the mix, because unlike Guillaume le Million you are a police officer. It's your nifty little way to say: I'm armed and dangerous.",
                                               "polish": "Czasami dodajesz jeszcze do tego pistolety z palców, bo, inaczej niż Guillaume le Million, jesteś policjantem. To twój sposób, żeby powiedzieć: jestem uzbrojony i niebezpieczny.",
-                                              "belarusian": "Часам ты яшчэ дадаеш да гэтага пісталеты з пальцаў, бо, у адрозненне ад Гіёма ле Мільёна, ты паліцыянт. Гэта твой спосаб сказаць: я ўзброены і небяспечны.",
+                                              "belarusian": "Часам ты яшчэ дадаеш да гэтага пальцы-пісталеты, бо, у адрозненне ад Гіёма ле Мільёна, ты паліцыянт. Гэта твой спосаб сказаць: я ўзброены і небяспечны.",
                                               "links": []
                                             }
                                           ]

--- a/text/dialogues/3.json
+++ b/text/dialogues/3.json
@@ -80,7 +80,7 @@
                       "articyId": "0x010000510000917F",
                       "english": "Love... time... Revachol...",
                       "polish": "Miłość... czas... Revachol...",
-                      "belarusian": "Каханне... час... Рэвашоль...",
+                      "belarusian": "Каханне... час... Рэваколь...",
                       "links": [
                         {
                           "id": 109,
@@ -201,7 +201,7 @@
                                                                   "articyId": "0x0100005100009361",
                                                                   "english": "There's a lever in front of you. Pull it, and atomic fire blankets your beloved Revachol. Millions die in an instant. But you are spared. You, and the voice in the payphone.",
                                                                   "polish": "Przed sobą widzisz dźwignię. Pociągnij ją, a twój ukochany Revachol zatonie w atomowym ogniu. W mgnieniu oka zginą miliony. Ty jednak ocalejesz. Ty i głos w telefonie.",
-                                                                  "belarusian": "Перад сабой ты бачыш рычаг. Пацягні яго, і на Рэвашоль, тваё каханне, абрынецца атамны агонь. У імгненне вока загінуць мільёны. Але ты ацалееш. Ты і голас у таксафоне.",
+                                                                  "belarusian": "Перад сабой ты бачыш рычаг. Пацягні яго, і на Рэваколь, тваё каханне, абрынецца атамны агонь. У імгненне вока загінуць мільёны. Але ты ацалееш. Ты і голас у таксафоне.",
                                                                   "links": [
                                                                     {
                                                                       "id": 183,
@@ -234,7 +234,7 @@
                                                                               "articyId": "0x0100005100009221",
                                                                               "english": "While the world burns, the two of you, together again, ride an aerostatic into the sunset. Maybe it will work this time? Spare Revachol and you'll never hear from her again. Will you sacrifice a second chance at love to keep Revachol safe?",
                                                                               "polish": "Podczas gdy świat płonie, wy, znowu razem, odlatujecie aerostatem w stronę zachodzącego słońca. Może tym razem się uda? Oszczędź Revachol, a nigdy więcej się o ciebie nie upomni. Czy poświęcisz kolejną szansę na miłość, aby ochronić Revachol?",
-                                                                              "belarusian": "Пакуль свет палае, вы ўдваіх, зноў разам, адлятаеце аэрастатыкам у бок заходу сонца. Можа, гэтым разам атрымаецца? Зберажы Рэвашоль, і ты больш ніколі пра яе нічога не пачуеш. Ці ахвяруеш ты яшчэ адным шанцам на каханне, каб абараніць Рэвашоль?",
+                                                                              "belarusian": "Пакуль свет палае, вы ўдваіх, зноў разам, адлятаеце аэрастатыкам у бок заходу сонца. Можа, гэтым разам атрымаецца? Зберажы Рэваколь, і ты больш ніколі пра яе нічога не пачуеш. Ці ахвяруеш ты яшчэ адным шанцам на каханне, каб абараніць Рэваколь?",
                                                                               "links": [
                                                                                 {
                                                                                   "id": 209,
@@ -319,7 +319,7 @@
                                                                                       "articyId": "0x01000051000091AE",
                                                                                       "english": "(Bow down.) Yes. My heart forever beats for Revachol, I am all she has left. The constant kingsman.",
                                                                                       "polish": "(Ukłoń się). Tak. Moje serce będzie zawsze bić dla Revacholu. Jestem wszystkim, co mu zostało. Wiecznym rojalistą.",
-                                                                                      "belarusian": "(Пакланіцца.) Так. Маё сэрца заўсёды будзе біцца за Рэвашоль. Я — ўсё, што ў яе засталося. Вечны раяліст.",
+                                                                                      "belarusian": "(Пакланіцца.) Так. Маё сэрца заўсёды будзе біцца за Рэвашоль. Я — усё, што ў яе засталося. Вечны раяліст.",
                                                                                       "links": [
                                                                                         {
                                                                                           "id": 232,
@@ -810,7 +810,7 @@
                                                                                           "articyId": "0x0100005100009319",
                                                                                           "english": "Your heart can belong to Revachol or it can belong to darkness. As long as it's torn between them it's broken and useless.",
                                                                                           "polish": "Twoje serce może należeć do Revacholu lub należeć do mroku. Dopóki pozostaje między nimi rozdarte, nie zdaje się na nic.",
-                                                                                          "belarusian": "Тваё сэрца можа належаць Рэвашоль або належаць цемры. Пакуль яно разрываецца паміж імі, яно ні да чаго не прыдатнае.",
+                                                                                          "belarusian": "Тваё сэрца можа належаць Рэваколь або належаць цемры. Пакуль яно разрываецца паміж імі, яно ні да чаго не прыдатнае.",
                                                                                           "links": []
                                                                                         }
                                                                                       ]
@@ -835,7 +835,7 @@
                                                                                           "articyId": "0x01000051000092D6",
                                                                                           "english": "You will be free to love Revachol like no one has ever loved her. You will be her champion, and she will be *faithful* to you. If you can just make this last sacrifice, you will *finally* know happiness.",
                                                                                           "polish": "Będziesz mógł kochać Revachol, jak nikt go nigdy nie kochał. Będziesz jego czempionem, a on będzie ci *wierną kochanką*. Jeśli zdołasz tylko dokonać tej ostatniej ofiary, *w końcu* zaznasz szczęścia.",
-                                                                                          "belarusian": "Ты зможаш любіць Рэвашоль, як ніхто ніколі яе не любіў. Ты будзеш яе рыцарам, а яна будзе табе *дамай сэрца*. Калі толькі зможаш прынесці гэтую апошнюю ахвяру, *нарэшце* адчуеш шчасце.",
+                                                                                          "belarusian": "Ты зможаш любіць Рэваколь, як ніхто ніколі яе не любіў. Ты будзеш яе рыцарам, а яна будзе табе *дамай сэрца*. Калі толькі зможаш прынесці гэтую апошнюю ахвяру, *нарэшце* адчуеш шчасце.",
                                                                                           "links": [
                                                                                             {
                                                                                               "id": 295,

--- a/text/dialogues/3.json
+++ b/text/dialogues/3.json
@@ -201,7 +201,7 @@
                                                                   "articyId": "0x0100005100009361",
                                                                   "english": "There's a lever in front of you. Pull it, and atomic fire blankets your beloved Revachol. Millions die in an instant. But you are spared. You, and the voice in the payphone.",
                                                                   "polish": "Przed sobą widzisz dźwignię. Pociągnij ją, a twój ukochany Revachol zatonie w atomowym ogniu. W mgnieniu oka zginą miliony. Ty jednak ocalejesz. Ty i głos w telefonie.",
-                                                                  "belarusian": "Перад сабой ты бачыш рычаг. Пацягні яго, і на Рэвашоль, тваё каханне, абрынецца атамны агонь. У імгненне вока загінуць мільёны. Але ты ацалееш. Ты і голас у тэлефоне.",
+                                                                  "belarusian": "Перад сабой ты бачыш рычаг. Пацягні яго, і на Рэвашоль, тваё каханне, абрынецца атамны агонь. У імгненне вока загінуць мільёны. Але ты ацалееш. Ты і голас у таксафоне.",
                                                                   "links": [
                                                                     {
                                                                       "id": 183,

--- a/text/dialogues/3.json
+++ b/text/dialogues/3.json
@@ -2417,7 +2417,7 @@
                                                                           "articyId": "0x01000004000058A4",
                                                                           "english": "No one tells me what to do.",
                                                                           "polish": "Nikt nie będzie mi mówił, co mam robić.",
-                                                                          "belarusian": "Ніхто не будзе мне указваць, што рабіць.",
+                                                                          "belarusian": "Ніхто не будзе мне ўказваць, што рабіць.",
                                                                           "links": [
                                                                             {
                                                                               "id": 203,

--- a/text/dialogues/32.json
+++ b/text/dialogues/32.json
@@ -12,7 +12,7 @@
       "articyId": "0x010000040001528A",
       "english": "This isn't just glass -- these are old computation components.",
       "polish": "To nie jest zwykłe szkło – to stare komponenty komputerowe.",
-      "belarusian": "Гэта не проста шкло – гэта старыя камп'ютарныя кампаненты.",
+      "belarusian": "Гэта не проста шкло — гэта старыя камп'ютарныя кампаненты.",
       "links": [
         {
           "id": 13,
@@ -56,7 +56,7 @@
                       "articyId": "0x01000004000152BC",
                       "english": "The 'how' was a closely guarded secret. Something that was locked in safes and human heads across the river where they were manufactured. As to why? Your fingers don't know.",
                       "polish": "„Jak” stanowiło pilnie strzeżony sekret. Coś, co trzymano zamknięte w sejfach i ludzkich głowach po drugiej stronie rzeki, gdzie produkowano te elementy. A po co? Twoje palce nie wiedzą.",
-                      "belarusian": "\"Як\" — гэта была таямніца, якая старанна ахоўвалася. Якая была зачынена ў сейфах і чалавечых галовах на іншым баку ракі, дзе вырабляліся гэтыя элементы. А навошта? Твае пальцы не ведаюць.",
+                      "belarusian": "'Як' — гэта была таямніца, якая старанна ахоўвалася. Якая была зачынена ў сейфах і чалавечых галовах на іншым баку ракі, дзе вырабляліся гэтыя элементы. А навошта? Твае пальцы не ведаюць.",
                       "links": [
                         {
                           "id": 7,
@@ -67,7 +67,7 @@
                           "articyId": "0x010000060001E694",
                           "english": "The 'why' is easy -- because they hadn't come up with modern silicon-based systems yet. For vitreous-cast filament memories, though, these seem incredibly advanced.",
                           "polish": "Po co? To łatwe. Bo nie wymyślili jeszcze współczesnych elementów krzemowych. Te konkretne wyglądają na niesamowicie zaawansowane jak na szklane pamięci włosowate.",
-                          "belarusian": "Навошта? Гэта лёгка. Бо яшчэ не прыдумалі сучасныя элементы з крэмнію. Гэтыя канкрэтныя выглядаюць надзвычай прагрэсіўна для шкляных валаконных кубоў памяці.",
+                          "belarusian": "Навошта? Гэта лёгка. Бо яшчэ не прыдумалі сучасныя элементы з крэмню. Гэтыя канкрэтныя выглядаюць надзвычай прагрэсіўна для шкляных валаконных кубоў памяці.",
                           "links": []
                         }
                       ]
@@ -94,7 +94,7 @@
                       "articyId": "0x01000004000152CB",
                       "english": "The lieutenant tilts his head, watching the light glimmer on the glass. \"So it is. I think these used to form a single system, slotted in the wall.\"",
                       "polish": "Porucznik przechyla głowę i przygląda się połyskiwaniu światła w szkle. „Rzeczywiście. Zdaje się, że te elementy umieszczone w ścianie tworzyły pojedynczy system”.",
-                      "belarusian": "Лейтэнант нахіляе галаву і прыглядаецца да водбліскаў святла на шкле. \"Сапраўды. Здаецца, што гэтыя элементы, размешчаныя ў сцяне, утваралі адзіную сістэму\".",
+                      "belarusian": "Лейтэнант нахіляе галаву і прыглядаецца да водбліскаў святла на шкле: \"Сапраўды. Здаецца, што гэтыя элементы, размешчаныя ў сцяне, утваралі адзіную сістэму\".",
                       "links": []
                     }
                   ]
@@ -119,7 +119,7 @@
                       "articyId": "0x0100000600014F26",
                       "english": "He nods. \"The rest of the building seems to have been picked clean.\"",
                       "polish": "Kiwa głową. „Pozostałe pomieszczenia zostały wyprzątnięte do czysta”.",
-                      "belarusian": "Ён ківае. \"Здаецца, астатнія пакоі былі вычышчаны да бляску\".",
+                      "belarusian": "Ён ківае: \"Здаецца, астатнія пакоі былі вычышчаны да бляску\".",
                       "links": []
                     }
                   ]
@@ -171,7 +171,7 @@
                   "articyId": "0x01000004000152A7",
                   "english": "[Finish thought.]",
                   "polish": "[Zakończ myśl].",
-                  "belarusian": "[Скончыць думку].",
+                  "belarusian": "[Скончыць думку.]",
                   "links": []
                 }
               ]
@@ -187,7 +187,7 @@
           "articyId": "0x0100000400015296",
           "english": "[Discard thought.]",
           "polish": "[Odrzuć myśl].",
-          "belarusian": "[Адкінуць думку].",
+          "belarusian": "[Адкінуць думку.]",
           "links": []
         }
       ]

--- a/text/dialogues/5.json
+++ b/text/dialogues/5.json
@@ -265,7 +265,7 @@
                                                   "articyId": "0x0100000B00002D71",
                                                   "english": "You instinctively run your hand over your multi-patterned orange tie. The sensation of wrinkled silk somehow makes the name sound even cooler.",
                                                   "polish": "Instynktownie przesuwasz ręką po swoim wzorzystym, pomarańczowym krawacie. Dotyk pogniecionego jedwabiu sprawia, że imię to brzmi z jakiegoś powodu jeszcze bardziej czadowo.",
-                                                  "belarusian": "Ты машынальна праводзіш рукой па сваім шматузорным памаранчавым гальштуку. Адчуванне памятага шоўку па нейкай прычыне робіць гэтае імя яшчэ больш хвэцкім.",
+                                                  "belarusian": "Ты машынальна праводзіш рукой па сваім шматузорным памаранчавым гальштуку. Адчуванне памятага ядвабу па нейкай прычыне робіць гэтае імя яшчэ больш хвэцкім.",
                                                   "links": [
                                                     {
                                                       "id": 7,
@@ -393,7 +393,7 @@
                                                   "articyId": "0x0100000B00002D7F",
                                                   "english": "You instinctively run your hand over the multi-patterned silk of your tie. Its slickness gives you comfort and reassurance.",
                                                   "polish": "Instynktownie przesuwasz dłonią po wzorzystym jedwabiu swojego krawata. Jego gładkość zapewnia ci ukojenie i dodaje pewności siebie.",
-                                                  "belarusian": "Ты машынальна праводзіш рукой па шматузорным шоўку свайго гальштука. Ягоная гладкасць супакойвае і дае ўпэўненасць у сабе.",
+                                                  "belarusian": "Ты машынальна праводзіш рукой па шматузорнаму ядвабу свайго гальштука. Ягоная гладкасць супакойвае і дае ўпэўненасць у сабе.",
                                                   "links": [
                                                     {
                                                       "id": 88,
@@ -820,7 +820,7 @@
                                                                                       "articyId": "0x0100000B00002FA4",
                                                                                       "english": "\"...where it has been hanging for seven days straight. We should go there as soon as we're done talking to the owner.\"",
                                                                                       "polish": "„...na którym wiszą nieprzerwanie od siedmiu dni. Musimy się nimi zająć, jak tylko skończymy rozmowę z właścicielem lokalu”.",
-                                                                                      "belarusian": "\"...на якім яно бесперапынна вісіць ужо сем дзён. Мы павінны пайсці да яго, як толькі скончым размову з уладальнікам памяшкання\".",
+                                                                                      "belarusian": "\"...на якім яно бесперапынна вісіць ужо сем дзён. Мы павінны пайсці да яго, як толькі скончым размову з уласнікам\".",
                                                                                       "links": [
                                                                                         {
                                                                                           "id": 176,

--- a/text/dialogues/5.json
+++ b/text/dialogues/5.json
@@ -393,7 +393,7 @@
                                                   "articyId": "0x0100000B00002D7F",
                                                   "english": "You instinctively run your hand over the multi-patterned silk of your tie. Its slickness gives you comfort and reassurance.",
                                                   "polish": "Instynktownie przesuwasz dłonią po wzorzystym jedwabiu swojego krawata. Jego gładkość zapewnia ci ukojenie i dodaje pewności siebie.",
-                                                  "belarusian": "Ты машынальна праводзіш рукой па шматузорнаму ядвабу свайго гальштука. Ягоная гладкасць супакойвае і дае ўпэўненасць у сабе.",
+                                                  "belarusian": "Ты машынальна праводзіш рукой па шматузорным ядвабе свайго гальштука. Ягоная гладкасць супакойвае і дае ўпэўненасць у сабе.",
                                                   "links": [
                                                     {
                                                       "id": 88,

--- a/text/dialogues/5.json
+++ b/text/dialogues/5.json
@@ -168,7 +168,7 @@
                                           "articyId": "0x0100000B00002E1E",
                                           "english": "\"You seem a little unsure, officer. Have you spent too much time undercover lately?\" He cracks an uneasy smile to let you know it's a joke.",
                                           "polish": "„Nie zabrzmiało to zbyt pewnie, oficerze. Nie spędziłeś ostatnio zbyt wiele czasu pod przykrywką?” – pyta, uśmiechając się niepewnie, abyś wiedział, że żartuje.",
-                                          "belarusian": "\"Гэта прагучала крыху няўпэўнена, афіцэру. Ці не правялі вы надоечы шмат часу пад прыкрыццём?\" — ён няёмка усміхаецца, каб даць табе ведаць, што гэта жарт.",
+                                          "belarusian": "\"Гэта прагучала крыху няўпэўнена, афіцэру. Ці не правялі вы надоечы шмат часу пад прыкрыццём?\" — ён няёмка ўсміхаецца, каб даць табе ведаць, што гэта жарт.",
                                           "links": []
                                         }
                                       ]

--- a/text/dialogues/6.json
+++ b/text/dialogues/6.json
@@ -522,7 +522,7 @@
                                                                           "articyId": "0x0100000400006949",
                                                                           "english": "The lieutenant nods at you affirmatively, then glances at the exit. \"The body was behind the building, right -- how do we get there?\"",
                                                                           "polish": "Porucznik kiwa głową i zerka na wyjście. „Ciało znajduje się za budynkiem – jak tam trafić?”",
-                                                                          "belarusian": "Лейтэнант ківае, пасля чаго кідае позірк на выхад. \"Цела знаходзіцца за будынкам — як туды трапіць?\"",
+                                                                          "belarusian": "Лейтэнант ківае, пасля чаго кідае позірк на выхад: \"Цела знаходзіцца за будынкам — як туды трапіць?\"",
                                                                           "links": []
                                                                         }
                                                                       ]
@@ -1175,7 +1175,7 @@
                                       "articyId": "0x01000004000065B8",
                                       "english": "\"Of course -- if by \"The Law\" you mean *blood alcohol level*.\"",
                                       "polish": "„Oczywiście, jeśli przez *prawo* rozumiemy *poziom alkoholu we krwi*”.",
-                                      "belarusian": "\"Бязумоўна — калі пад *Законам* ты маеш на ўвазе *ўзровень алкаголю ў крыві*\".",
+                                      "belarusian": "\"Бязумоўна — калі пад \"Законам\" ты маеш на ўвазе *ўзровень алкаголю ў крыві*\".",
                                       "links": []
                                     },
                                     {
@@ -3499,7 +3499,7 @@
                                               "articyId": "0x01000004000062D4",
                                               "english": "\"Oh, excuse me. You owe me 130 *reál*.\" He pronounces the 'r' with a mock aristocratic accent.",
                                               "polish": "„Och, przepraszam. Jesteś mi winien 130 *reáli*” – odpowiada, wymawiając „r” z przesadnie arystokratycznym akcentem.",
-                                              "belarusian": "\"Ой, прабачце. Вы мне павінны 130 *рэалаў*\", — ён расцягвае гук \"р\" з прытворна-арыстакратычным акцэнтам.",
+                                              "belarusian": "\"Ой, прабачце. Вы мне павінны 130 *рэалаў*\", — ён расцягвае гук 'р' з прытворна-арыстакратычным акцэнтам.",
                                               "links": [
                                                 {
                                                   "id": 649,
@@ -4202,7 +4202,7 @@
                                                                                           "articyId": "0x01000004000071C3",
                                                                                           "english": "\"It's a joke, sweetie. I didn't actually think you saw the Kind Green Ape of South Safre in a hostel in Martinaise. That would be ridiculous. Are you okay?\"",
                                                                                           "polish": "„To żart, skarbeńku. Nie myślałam, że zobaczysz w martyneskim hostelu życzliwą zieloną małpę z Południowego Safre. To by było absurdalne. Nic ci nie jest?”",
-                                                                                          "belarusian": "\"Гэта жарт, мілы. Я насамрэч не думала, што ў гатэлі Марцінэза ты пабачыш Ветлівую Зялёную Малпу з Паўднёвага Сафрэ. Гэта было б абсурдна. Ты ў парадку?\"",
+                                                                                          "belarusian": "\"Гэта жарт, мілы. Я насамрэч не думала, што ў хостэле Марцінэза ты пабачыш Ветлівую Зялёную Малпу з Паўднёвага Сафрэ. Гэта было б абсурдна. Ты ў парадку?\"",
                                                                                           "links": []
                                                                                         }
                                                                                       ]
@@ -4671,7 +4671,7 @@
                                                                           "articyId": "0x0100000400006C61",
                                                                           "english": "\"Money is what grown up people use to pay for things. Things like this hostel room or...\" He peeks into the ledger: \"...or eight bottles of 'Potent Blend' and nine packs of 'Royal Extra'. We use it for everything, really.\"",
                                                                           "polish": "„Pieniądze to te papierki, którymi dorośli ludzie płacą za różne rzeczy. Rzeczy takie jak nocleg w tym hostelu czy...” – zagląda do księgi rachunkowej – „...czy osiem butelek »Mocnej Mieszanki« i dziewięć paczek »Królewskich Ekstra«. Kupujemy za nie właściwie wszystko”.",
-                                                                          "belarusian": "\"Грошы — гэта тыя паперкі, якімі дарослыя людзі плацяць за розныя рэчы. Такія, як начлег у гэтым хостэле ці... — ён зазірае ў бухгалтарскую кнігу. — ... восем бутэлек \"Potent Blend\" і дзевяць пакункаў \"Royal Extra\". Мы купляем за іх фактычна ўсё\".",
+                                                                          "belarusian": "\"Грошы — гэта тыя паперкі, якімі дарослыя людзі плацяць за розныя рэчы. Такія, як начлег у гэтым хостэле ці... — ён зазірае ў бухгалтарскую кнігу. — ...восем бутэлек 'Заборыстага' і дзевяць пачак 'Каралеўскага Экстра'. Мы купляем за іх фактычна ўсё\".",
                                                                           "links": [
                                                                             {
                                                                               "id": 561,
@@ -4776,7 +4776,7 @@
                                                                                   "articyId": "dvauk5afawb1pkds",
                                                                                   "english": "There's a shuffle of nylon as Lieutenant Kitsuragi looks for something in the pockets of his orange bomber.",
                                                                                   "polish": "Słyszysz szelest nylonu, gdy porucznik Kitsuragi szuka czegoś w kieszeniach swojej pomarańczowej bomberki.",
-                                                                                  "belarusian": "Ты чуеш шоргат нейлону, калі лейтэнант Кіцурагі шукае нешта ў кішэнях свайго аранжавага бомбера.",
+                                                                                  "belarusian": "Ты чуеш шоргат нейлону, калі лейтэнант Кіцурагі шукае нешта ў кішэнях свайго памаранчавага бомбера.",
                                                                                   "alternates": {
                                                                                     "Alternate1": {
                                                                                       "english": "There's a shuffle of nylon as Lieutenant Kitsuragi looks for something in the pockets of his black bomber.",
@@ -5194,7 +5194,7 @@
                                                                               "articyId": "0x010000040000708A",
                                                                               "english": "\"'Refusal to aid an officer of the peace.' You are impeding me from carrying out a murder investigation with your inane requests for money.\"",
                                                                               "polish": "„Odmowa pomocy stróżowi prawa i porządku. Utrudnianie mi przeprowadzenia śledztwa niedorzecznymi żądaniami finansowymi”.",
-                                                                              "belarusian": "\"\"Адмова ў дапамозе ахоўніку права і парадку\". Сваімі недарэчнымі фінансавымі патрабаваннямі ты перашкаджаеш мне весці расследаванне забойства\".",
+                                                                              "belarusian": "\"'Адмова ў дапамозе ахоўніку права і парадку'. Сваімі недарэчнымі фінансавымі патрабаваннямі ты перашкаджаеш мне весці расследаванне забойства\".",
                                                                               "links": [
                                                                                 {
                                                                                   "id": 300,
@@ -5446,7 +5446,7 @@
                                                                               "articyId": "0x0100000400007138",
                                                                               "english": "\"You have admitted to *sexual* crimes. You will be taken to *sex* prison.\"",
                                                                               "polish": "„Przyznałeś się do przestępstw na tle *seksualnym*. Zostaniesz zabrany do *seksualnego* więzienia”.",
-                                                                              "belarusian": "\"Ты прызнаўся ў злачынствах на *сэксуальнай* глебе. Ты будзеш дастаўлены ў *сэксуальную* турму\".",
+                                                                              "belarusian": "\"Ты прызнаўся ў злачынствах на *сексуальнай* глебе. Ты будзеш дастаўлены ў *сексуальную* турму\".",
                                                                               "links": [
                                                                                 {
                                                                                   "id": 566,
@@ -5457,7 +5457,7 @@
                                                                                   "articyId": "0x0100000400007147",
                                                                                   "english": "He laughs. \"What in the name of God...\"",
                                                                                   "polish": "Śmieje się. „Co ty wygadujesz, na boga...?”",
-                                                                                  "belarusian": "Ён смяецца. \"Што, у імя Бога...?\"",
+                                                                                  "belarusian": "Ён смяецца: \"Што, у імя Бога...?\"",
                                                                                   "links": [
                                                                                     {
                                                                                       "id": 49,
@@ -5733,7 +5733,7 @@
                                                                                                           "articyId": "0x010000040000704E",
                                                                                                           "english": "The man starts to say something, but then thinks better of it. \"Good luck.\"",
                                                                                                           "polish": "Mężczyzna zaczyna coś mówić, ale po chwili gryzie się w język. „Powodzenia”.",
-                                                                                                          "belarusian": "Мужчына пачынае нешта гаварыць, але праз момант перадумвае. \"Поспехаў\".",
+                                                                                                          "belarusian": "Мужчына пачынае нешта гаварыць, але праз момант перадумвае: \"Поспехаў\".",
                                                                                                           "links": []
                                                                                                         }
                                                                                                       ]
@@ -5884,7 +5884,7 @@
                                                                                   "articyId": "0x010000040000705C",
                                                                                   "english": "The man wants to say something, then thinks better of it. \"Good luck.\"",
                                                                                   "polish": "Mężczyzna chce coś powiedzieć, ale po chwili gryzie się w język. „Powodzenia”.",
-                                                                                  "belarusian": "Мужчына хоча нешта сказаць, але праз момант перадумвае. \"Поспехаў\".",
+                                                                                  "belarusian": "Мужчына хоча нешта сказаць, але праз момант перадумвае: \"Поспехаў\".",
                                                                                   "links": []
                                                                                 }
                                                                               ]

--- a/text/dialogues/6.json
+++ b/text/dialogues/6.json
@@ -4671,7 +4671,7 @@
                                                                           "articyId": "0x0100000400006C61",
                                                                           "english": "\"Money is what grown up people use to pay for things. Things like this hostel room or...\" He peeks into the ledger: \"...or eight bottles of 'Potent Blend' and nine packs of 'Royal Extra'. We use it for everything, really.\"",
                                                                           "polish": "„Pieniądze to te papierki, którymi dorośli ludzie płacą za różne rzeczy. Rzeczy takie jak nocleg w tym hostelu czy...” – zagląda do księgi rachunkowej – „...czy osiem butelek »Mocnej Mieszanki« i dziewięć paczek »Królewskich Ekstra«. Kupujemy za nie właściwie wszystko”.",
-                                                                          "belarusian": "\"Грошы — гэта тыя паперкі, якімі дарослыя людзі плацяць за розныя рэчы. Такія, як начлег у гэтым хостэле ці... — ён зазірае ў бухгалтарскую кнігу. — ...восем бутэлек 'Заборыстага' і дзевяць пачак 'Каралеўскага Экстра'. Мы купляем за іх фактычна ўсё\".",
+                                                                          "belarusian": "\"Грошы — гэта тыя паперкі, якімі дарослыя людзі плацяць за розныя рэчы. Такія, як начлег у гэтым хостэле ці... — ён зазірае ў бухгалтарскую кнігу. — ...восем бутэлек 'Магутнай Сумесі' і дзевяць пачак 'Каралеўскіх Экстра'. Мы купляем за іх фактычна ўсё\".",
                                                                           "links": [
                                                                             {
                                                                               "id": 561,

--- a/text/dialogues/6.json
+++ b/text/dialogues/6.json
@@ -3894,7 +3894,7 @@
                                                                                                   "articyId": "0x0100008100002FF6",
                                                                                                   "english": "\"Are you sure, ma'am?\"",
                                                                                                   "polish": "„Na pewno?”",
-                                                                                                  "belarusian": "\"Вы ўпэўнены, мадам?\"",
+                                                                                                  "belarusian": "\"Вы ўпэўнены, спадарыня?\"",
                                                                                                   "links": [
                                                                                                     {
                                                                                                       "id": 402,
@@ -3934,7 +3934,7 @@
                                                                                               "articyId": "0x0100008100002FEE",
                                                                                               "english": "\"Ma'am, are you alright?\"",
                                                                                               "polish": "„Proszę pani, wszystko w porządku?”",
-                                                                                              "belarusian": "\"Мадам, вы ў парадку?\"",
+                                                                                              "belarusian": "\"Спадарыня, вы ў парадку?\"",
                                                                                               "links": [
                                                                                                 {
                                                                                                   "id": 213,

--- a/text/dialogues/6.json
+++ b/text/dialogues/6.json
@@ -5194,7 +5194,7 @@
                                                                               "articyId": "0x010000040000708A",
                                                                               "english": "\"'Refusal to aid an officer of the peace.' You are impeding me from carrying out a murder investigation with your inane requests for money.\"",
                                                                               "polish": "„Odmowa pomocy stróżowi prawa i porządku. Utrudnianie mi przeprowadzenia śledztwa niedorzecznymi żądaniami finansowymi”.",
-                                                                              "belarusian": "\"'Адмова ў дапамозе ахоўніку права і парадку'. Сваімі недарэчнымі фінансавымі патрабаваннямі ты перашкаджаеш мне весці расследаванне забойства\".",
+                                                                              "belarusian": "\"'Адмова ў дапамозе ахоўніку правапарадку'. Сваімі недарэчнымі фінансавымі патрабаваннямі ты перашкаджаеш мне весці расследаванне забойства\".",
                                                                               "links": [
                                                                                 {
                                                                                   "id": 300,

--- a/text/dialogues/73.json
+++ b/text/dialogues/73.json
@@ -12,7 +12,7 @@
       "articyId": "0x0100000800002908",
       "english": "This is it -- the scene of the party. The fire pit, cigarettes, and empty bottles all evidence it.",
       "polish": "Oto jest – miejsce imprezy. Pozostałość po ogniu, papierosy i puste butelki, niezbite dowody.",
-      "belarusian": "Вось яно – месца вечарыны. Вогнішча, цыгарэты і пустыя бутэлькі – усё сведчыць аб гэтым.",
+      "belarusian": "Вось яно — месца вечарыны. Вогнішча, цыгарэты і пустыя бутэлькі — усё сведчыць аб гэтым.",
       "links": [
         {
           "id": 10,
@@ -103,7 +103,7 @@
                               "articyId": "0x010000080000294A",
                               "english": "\"Hey -- let's keep moving, detective.\" The lieutenant adjusts his glasses.",
                               "polish": "„Hej, ruszajmy dalej, detektywie” – porucznik poprawia swoje okulary.",
-                              "belarusian": "\"Гэй, хадземце далей, дэтэктыве\", – лейтэнант папраўляе свае акуляры.",
+                              "belarusian": "\"Гэй, хадземце далей, дэтэктыве\", — лейтэнант папраўляе свае акуляры.",
                               "links": [
                                 {
                                   "id": 13,
@@ -142,7 +142,7 @@
                           "articyId": "0x0100000800002960",
                           "english": "\"Was this party against the law? On the ice like this -- it was probably a public danger.\"",
                           "polish": "„Czy ta impreza była niezgodna z prawem? Takie rzeczy na lodzie to chyba publiczne zagrożenie”.",
-                          "belarusian": "\"Гэтая вечарынка была незаконнай? Вось так, на лёдзе – яна верагодна з'яўлялася пагрозай грамадству\".",
+                          "belarusian": "\"Гэтая вечарынка была незаконнай? Вось так, на лёдзе — яна верагодна з'яўлялася пагрозай грамадству\".",
                           "links": [
                             {
                               "id": 12,
@@ -187,7 +187,7 @@
           "articyId": "0x0100000800002923",
           "english": "(Dismiss thought.)",
           "polish": "(Odrzuć myśl).",
-          "belarusian": "(Адрынуць думку).",
+          "belarusian": "(Адрынуць думку.)",
           "links": []
         }
       ]

--- a/text/dialogues/73.json
+++ b/text/dialogues/73.json
@@ -142,7 +142,7 @@
                           "articyId": "0x0100000800002960",
                           "english": "\"Was this party against the law? On the ice like this -- it was probably a public danger.\"",
                           "polish": "„Czy ta impreza była niezgodna z prawem? Takie rzeczy na lodzie to chyba publiczne zagrożenie”.",
-                          "belarusian": "\"Гэтая вечарынка была незаконнай? Вось так, на лёдзе — яна верагодна з'яўлялася пагрозай грамадству\".",
+                          "belarusian": "\"Гэтая вечарынка была незаконнай? Вось так, на лёдзе — яна, верагодна, з'яўлялася пагрозай грамадству\".",
                           "links": [
                             {
                               "id": 12,


### PR DESCRIPTION
праверыла дыялогі 1, 2, 32, 73, 6, 3, 5, 23 на:
- фразы ў дужках (каб кропка была ўнутры);
- адзінарныя двукоссі так як у арыгінале;
- доўгія працяжнікі;
- двукроп'е пасля слоў аўтара перад простай мовай.

Акрамя гэтага выправіла:
"мозг" на "мазгі"
"крэмній" на "крэмн"
"гатэль" на "хостэл"
Royal Extra - Каралеўскае Экстра (pack - пакунак на пачка), potent blend - "Заборыстае"
аранжавы (бомбер) - памаранчавы
сэксуальный - сексуальнай
espirit de corps - "зводных братоў і сясцёр" на "крэўных братоў і сясцёр" (было крэўны брат у дыялогу 5)
finger pistols - "пальцы з пісталетаў" на "пальцы-пісталеты"
"шоўк" на "ядваб"
owner "уладальнік памяшкання" на "уласнік"

