### PR TITLE
Выпраўленне heavy fuel oil

### DIFF
--- a/text/dialogues/28.json
+++ b/text/dialogues/28.json
@@ -12,7 +12,7 @@
       "articyId": "0x010000210000105A",
       "english": "Paintbrush -- check, heavy fuel oil -- check... Now the only thing left to do is paint the wall.",
       "polish": "Pędzel – jest. Ciężki olej napędowy – jest. Pozostało tylko pomalować ścianę.",
-      "belarusian": "Пэндзаль — ёсць. Мазута — ёсць... Засталося толькі пафарбаваць сцяну.",
+      "belarusian": "Пэндзаль — ёсць. Дызельнае паліва — ёсць... Засталося толькі пафарбаваць сцяну.",
       "links": []
     },
     {

--- a/text/dialogues/86.json
+++ b/text/dialogues/86.json
@@ -23,7 +23,7 @@
           "articyId": "0x0100000F000070DB",
           "english": "Heavy fuel oil, mostly. Because it's an industrial harbour.",
           "polish": "Głównie ciężkim olejem napędowym. W końcu to port przemysłowy.",
-          "belarusian": "Мазута, пераважна. Бо гэта ж індустрыйны порт.",
+          "belarusian": "Дызельнае паліва, пераважна. Бо гэта ж індустрыйны порт.",
           "links": [
             {
               "id": 31,

--- a/text/dialogues/89.json
+++ b/text/dialogues/89.json
@@ -166,7 +166,7 @@
                               "articyId": "0x0100000F000079F4",
                               "english": "But then the unmistakable reek of *seagull shit* hits you, buoyed along on the air currents, an acrid melody atop mouldering chords of wood rot and heavy fuel oil.",
                               "polish": "Później jednak dociera do ciebie niesiony prądami powietrza, niemożliwy do pomylenia z czymkolwiek innym smród *mewiego gówna*. Kwaśna melodia zbudowana na gnuśnych akordach gnijącego drewna i ciężkiego oleju napędowego.",
-                              "belarusian": "І тут цябе б'е ў нос відавочны смурод *гаўна кірляў*, падхоплены патокамі паветра. З'едлівы матыў па-над затхлымі нотамі гнілога дрэва і цяжкай мазуты.",
+                              "belarusian": "І тут цябе б'е ў нос відавочны смурод *гаўна кірляў*, падхоплены патокамі паветра. З'едлівы матыў па-над затхлымі нотамі гнілога дрэва і дызельнага паліва.",
                               "links": [
                                 {
                                   "id": 21,


### PR DESCRIPTION
Выпраўлена з "мазута" на "дызельнае паліва"